### PR TITLE
Fix kernel download URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sunodo-sdk-image: linux.bin
 	docker build --tag sunodo/sdk:0.2.0-sandboxing --file sunodo-sdk.Dockerfile --progress plain .
 
 linux.bin:
-	wget -O linux.bin https://github.com/edubart/riv/releases/download/downloads/linux.bin
+	wget -O linux.bin https://github.com/crypto-bug-hunters/bugless/releases/download/kernel/linux.bin
 
 test:
 	docker run -v $(shell pwd):/mnt --rm -it sunodo/sdk:0.2.0-sandboxing lua5.4 tests/tests.lua


### PR DESCRIPTION
Created release [kernel](https://github.com/crypto-bug-hunters/bugless/releases/tag/kernel)
Closes #73 