### PR TITLE
Fix dependency table

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,11 @@ To help you figure out which dependencies you actually need, here is a table of 
 
 | Dependency | Presentation | Back-end | Examples | Tests | Populate | CLI | Front-end |
 | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `docker` | ☑️ | ☑️ | ☑️ | | | | |
-| `go` | | ☑️ | | | ☑️ | ☑️ | |
+| `docker` | ☑️ | ☑️ | ☑️ | ☑️ | | | |
+| `go` | | | | | ☑️ | ☑️ | |
 | `jq` | | | | | ☑️ | | |
-| `lua` | | | | ☑️ | | | |
 | `pnpm` | | | | | | | ☑️ |
 | `sunodo` | | ☑️ | | ☑️ | | | |
-| `tar` | | | ☑️ | | | | |
 
 ## Presentation
 


### PR DESCRIPTION
Some dependencies aren't actually necessary on the host machine, as they are installed and run inside a Docker container:

- Back-end: `go`
- Examples: `tar`
- Tests: `lua`