### PR TITLE
Fix Solidity bounty Dockerfile

### DIFF
--- a/tests/bounties/solidity-bounty/Dockerfile
+++ b/tests/bounties/solidity-bounty/Dockerfile
@@ -7,4 +7,4 @@ COPY Makefile .
 COPY --chmod=755 start.sh .
 ARG VERSION
 RUN make download VERSION=${VERSION}
-RUN make -j`nproc` VERSION=${VERSION}
+RUN make VERSION=${VERSION}


### PR DESCRIPTION
The `-j` option makes the build unstable for some reason.
Removing it makes the build more stable at the expense of compile time.