### PR TITLE
Bump Rollmelette from v0.1.0 to v0.1.1

### DIFF
--- a/cli/cmd/send.go
+++ b/cli/cmd/send.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/gligneul/rollmelette"
+	"github.com/rollmelette/rollmelette"
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/test.go
+++ b/cli/cmd/test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/gligneul/rollmelette/integration"
+	"github.com/rollmelette/rollmelette/integration"
 	"github.com/spf13/cobra"
 )
 

--- a/contract/main.go
+++ b/contract/main.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/gligneul/rollmelette"
+	"github.com/rollmelette/rollmelette"
 	"github.com/holiman/uint256"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/Khan/genqlient v0.6.0
 	github.com/cartesi/rollups-node v1.3.0
 	github.com/ethereum/go-ethereum v1.13.12
-	github.com/gligneul/rollmelette v0.1.0
 	github.com/holiman/uint256 v1.2.4
+	github.com/rollmelette/rollmelette v0.1.1
 	github.com/spf13/cobra v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqG
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46 h1:BAIP2GihuqhwdILrV+7GJel5lyPV3u1+PgzrWLc0TkE=
 github.com/gballet/go-verkle v0.1.1-0.20231031103413-a67434b50f46/go.mod h1:QNpY22eby74jVhqH4WhDLDwxc/vqsern6pW+u2kbkpc=
-github.com/gligneul/rollmelette v0.1.0 h1:jsL09L9ipk4r1FDb5crZ0bhruNXepij8Gq/w0V8CvBk=
-github.com/gligneul/rollmelette v0.1.0/go.mod h1:EcdAH5wz7/Mb+6XlGGVYd+tThxB8yCglI5tsM4aeIgQ=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
@@ -159,6 +157,8 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rollmelette/rollmelette v0.1.1 h1:CphR5TwEr3XdBOI1bQViCDOqP84dkGYhEuZ7zfEjuBg=
+github.com/rollmelette/rollmelette v0.1.1/go.mod h1:YMk13JmVxa8lirxDn6HxPjo6XkRSAmGAdJm3Nm7sUEU=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=


### PR DESCRIPTION
Rollmelette v0.1.1 fixes a bug related to ERC-20 withdrawals, which we plan to support.
Also, the Rollmelette repository migrated to its own organization on GitHub.