### PR TITLE
Fix `.eslintrc.json`

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,4 +1,6 @@
 {
-    // adding next/babel to fix parsing error on next.conf.js
-    "extends": ["next/babel", "next/core-web-vitals"]
+    "extends": ["next/core-web-vitals"],
+    "rules": {
+        "@next/next/no-html-link-for-pages": ["error", "src/"]
+    }
 }


### PR DESCRIPTION
Sources:

- [StackOverflow question](https://stackoverflow.com/questions/71662525/failed-to-load-config-next-babel-to-extend-from-eslintrc-json)
- [Next.js GitHub issue](https://github.com/vercel/next.js/discussions/24254)

Closes #96